### PR TITLE
Bump Python dependencies and fix patches for upstream changes

### DIFF
--- a/layer/requirements.txt
+++ b/layer/requirements.txt
@@ -1,7 +1,8 @@
-# Sample file built from bedrock-access-gateway repo
-fastapi==0.115.6
-pydantic==2.10.4
-uvicorn==0.34.0
-requests==2.32.3
-boto3==1.38.27
-botocore==1.38.27
+fastapi==0.120.0
+pydantic==2.12.3
+pydantic-settings==2.11.0
+uvicorn==0.29.0
+tiktoken==0.6.0
+numpy==1.26.4
+boto3==1.40.59
+botocore==1.40.59

--- a/patches/app.py.patch
+++ b/patches/app.py.patch
@@ -1,10 +1,18 @@
 --- a/api/app.py
 +++ b/api/app.py
-@@ -6,7 +6,6 @@ from fastapi.responses import StreamingResponse
+@@ -5,7 +5,6 @@ from fastapi import FastAPI
+ from fastapi.exceptions import RequestValidationError
  from fastapi.middleware.cors import CORSMiddleware
- from fastapi.openapi.docs import get_swagger_ui_html
- from fastapi.staticfiles import StaticFiles
+ from fastapi.responses import PlainTextResponse
 -from mangum import Mangum
  
  from api.routers import chat, embeddings, model
- from api.setting import (
+ from api.setting import API_ROUTE_PREFIX, DESCRIPTION, SUMMARY, TITLE, VERSION
+@@ -47,7 +46,5 @@ async def validation_exception_handler(request, exc):
+     return PlainTextResponse(str(exc), status_code=400)
+ 
+ 
+-handler = Mangum(app)
+-
+ if __name__ == "__main__":
+     uvicorn.run("app:app", host="0.0.0.0", port=8000, reload=True)

--- a/patches/pydantic-version.patch
+++ b/patches/pydantic-version.patch
@@ -1,9 +1,9 @@
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,5 +1,5 @@
- mangum==0.19.0
- fastapi==0.115.6
--pydantic==2.10.4
-+pydantic>=2.10.4
- pydantic-settings==2.6.1
- uvicorn==0.34.0
+ fastapi==0.115.8
+-pydantic==2.7.1
++pydantic>=2.12.3
+ uvicorn==0.29.0
+ mangum==0.17.0
+ tiktoken==0.6.0

--- a/patches/requirements.txt.patch
+++ b/patches/requirements.txt.patch
@@ -1,7 +1,15 @@
 --- a/requirements.txt
 +++ b/requirements.txt
-@@ -1,4 +1,3 @@
--mangum==0.19.0
- fastapi==0.115.6
- pydantic==2.10.4
- pydantic-settings==2.6.1
+@@ -1,9 +1,8 @@
+-fastapi==0.115.8
+-pydantic==2.7.1
++fastapi==0.120.0
++pydantic==2.12.3
++pydantic-settings==2.11.0
+ uvicorn==0.29.0
+-mangum==0.17.0
+ tiktoken==0.6.0
+-requests==2.32.3
+ numpy==1.26.4
+ boto3==1.37.0
+ botocore==1.37.0

--- a/prepare_source.sh
+++ b/prepare_source.sh
@@ -38,29 +38,28 @@ rm -rf app/api
 rm -f layer/requirements.txt
 
 if [ -d "$REPO_DIR" ]; then
-    echo "Repository already cloned, fetching latest changes"
-    (cd $REPO_DIR && git fetch)
+    echo "Repository already cloned, resetting to clean state"
+    (cd $REPO_DIR && git reset --hard HEAD && git clean -fd)
 else
     echo "Cloning aws-samples/bedrock-access-gateway repository"
     git clone --depth 1 https://github.com/aws-samples/bedrock-access-gateway $REPO_DIR
 fi
-
-cp -r $REPO_DIR/src/api app/api
-cp $REPO_DIR/src/requirements.txt layer/requirements.txt
-
-echo "" > app/requirements.txt
 
 # Apply patches
 echo "Applying patches"
 (cd $REPO_DIR/src && patch -p1 < ../../../patches/auth.py.patch)
 (cd $REPO_DIR/src && patch -p1 < ../../../patches/app.py.patch)
 (cd $REPO_DIR/src && patch -p1 < ../../../patches/requirements.txt.patch)
-(cd $REPO_DIR/src && patch -p1 < ../../../patches/pydantic-version.patch)
 
 if [ "$NO_EMBEDDINGS" = true ]; then
     echo "Applying no-embeddings patch"
     (cd $REPO_DIR/src && patch -p1 < ../../../patches/no-embeddings.patch)
 fi
+
+cp -r $REPO_DIR/src/api app/api
+cp $REPO_DIR/src/requirements.txt layer/requirements.txt
+
+echo "" > app/requirements.txt
 
 # Update boto3/botocore to latest versions
 for pkg in boto3 botocore; do


### PR DESCRIPTION
- Update fastapi 0.115.6→0.120.0
- Update pydantic 2.10.4→2.12.3
- Update pydantic-settings 2.6.1→2.11.0
- Update boto3/botocore to latest (1.40.59)
- Fix patches to work with upstream bedrock-access-gateway changes
- Consolidate requirements.txt.patch to include all version updates
- Fix prepare_source.sh to apply patches before copying files
- Remove pydantic-version.patch application (merged into requirements.txt.patch)
- Tested successfully with Nova models in ap-southeast-1