### PR TITLE
feat: add Architecture parameter for arm64 Lambda support

### DIFF
--- a/template-with-secrets-manager.yaml
+++ b/template-with-secrets-manager.yaml
@@ -19,6 +19,13 @@ Parameters:
     Default: python3.12
     AllowedPattern: "^python3\\.([1-9][0-9]*)$"
     ConstraintDescription: "Must be a valid Python 3.x runtime (e.g., python3.12)"
+  Architecture:
+    Type: String
+    Description: "Lambda function architecture (x86_64 or arm64). Use arm64 for Graviton-based Lambda for better price-performance."
+    Default: x86_64
+    AllowedValues:
+      - x86_64
+      - arm64
   ApiKey:
     Type: String
     Description: "Pick a value of the API Key you want to be used in the Authorization header"
@@ -38,6 +45,13 @@ Parameters:
       - "true"
       - "false"
 
+Mappings:
+  ArchitectureMap:
+    x86_64:
+      AdapterLayerName: LambdaAdapterLayerX86
+    arm64:
+      AdapterLayerName: LambdaAdapterLayerArm64
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -46,6 +60,7 @@ Metadata:
         Parameters:
           - LambdaAdapterLayerVersion
           - PythonRuntime
+          - Architecture
       - Label:
           default: "Application Configuration"
         Parameters:
@@ -72,7 +87,7 @@ Resources:
       CompatibleRuntimes:
         - !Ref PythonRuntime
       CompatibleArchitectures:
-        - x86_64
+        - !Ref Architecture
     Metadata:
       BuildMethod: !Ref PythonRuntime
 
@@ -83,7 +98,7 @@ Resources:
       Handler: run.sh
       Runtime: !Ref PythonRuntime
       Architectures:
-        - x86_64
+        - !Ref Architecture
       Environment:
         Variables:
           API_KEY_SECRET_ARN: !Ref ApiKeySecret
@@ -95,7 +110,9 @@ Resources:
           ENABLE_CROSS_REGION_INFERENCE: 'true'
       Layers:
         - !Ref BedrockAccessGatewayLayer
-        - !Sub "arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:${LambdaAdapterLayerVersion}"
+        - !Sub
+          - "arn:aws:lambda:${AWS::Region}:753240598075:layer:${AdapterLayer}:${LambdaAdapterLayerVersion}"
+          - AdapterLayer: !FindInMap [ArchitectureMap, !Ref Architecture, AdapterLayerName]
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM

--- a/template.yaml
+++ b/template.yaml
@@ -18,6 +18,13 @@ Parameters:
     Default: python3.12
     AllowedPattern: "^python3\\.([1-9][0-9]*)$"
     ConstraintDescription: "Must be a valid Python 3.x runtime (e.g., python3.12)"
+  Architecture:
+    Type: String
+    Description: "Lambda function architecture (x86_64 or arm64). Use arm64 for Graviton-based Lambda for better price-performance."
+    Default: x86_64
+    AllowedValues:
+      - x86_64
+      - arm64
   ApiKey:
     Type: String
     Description: "Pick a value of the API Key you want to be used in the Authorization header"
@@ -37,6 +44,13 @@ Parameters:
       - "true"
       - "false"
 
+Mappings:
+  ArchitectureMap:
+    x86_64:
+      AdapterLayerName: LambdaAdapterLayerX86
+    arm64:
+      AdapterLayerName: LambdaAdapterLayerArm64
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -45,6 +59,7 @@ Metadata:
         Parameters:
           - LambdaAdapterLayerVersion
           - PythonRuntime
+          - Architecture
       - Label:
           default: "Application Configuration"
         Parameters:
@@ -65,7 +80,7 @@ Resources:
       CompatibleRuntimes:
         - !Ref PythonRuntime
       CompatibleArchitectures:
-        - x86_64
+        - !Ref Architecture
     Metadata:
       BuildMethod: !Ref PythonRuntime
 
@@ -76,7 +91,7 @@ Resources:
       Handler: run.sh
       Runtime: !Ref PythonRuntime
       Architectures:
-        - x86_64
+        - !Ref Architecture
       Environment:
         Variables:
           API_KEY: !Ref ApiKey
@@ -89,7 +104,9 @@ Resources:
           ENABLE_CROSS_REGION_INFERENCE: 'true'
       Layers:
         - !Ref BedrockAccessGatewayLayer
-        - !Sub "arn:aws:lambda:${AWS::Region}:753240598075:layer:LambdaAdapterLayerX86:${LambdaAdapterLayerVersion}"
+        - !Sub
+          - "arn:aws:lambda:${AWS::Region}:753240598075:layer:${AdapterLayer}:${LambdaAdapterLayerVersion}"
+          - AdapterLayer: !FindInMap [ArchitectureMap, !Ref Architecture, AdapterLayerName]
       FunctionUrlConfig:
         AuthType: NONE
         InvokeMode: RESPONSE_STREAM


### PR DESCRIPTION
## Summary

Add a CloudFormation parameter to select between `x86_64` and `arm64` Lambda architectures. This enables deployment on Graviton-based Lambda for better price-performance (~20% cheaper, ~20% faster).

## Changes

- Add `Architecture` parameter (default: `x86_64`, allowed: `x86_64`/`arm64`)
- Add `ArchitectureMap` mapping for Lambda Adapter Layer name resolution (`LambdaAdapterLayerX86` vs `LambdaAdapterLayerArm64`)
- Update `CompatibleArchitectures` and `Architectures` to reference the parameter
- Update Lambda Adapter Layer ARN to use `FindInMap` for correct layer selection
- Applied to both `template.yaml` and `template-with-secrets-manager.yaml`

## Usage

```bash
# Default (x86_64)
sam deploy --parameter-overrides ApiKey=your-key

# ARM64 (Graviton)
sam deploy --parameter-overrides ApiKey=your-key Architecture=arm64
```

> **Note:** When building with `sam build --use-container`, SAM will automatically select the correct container image based on the architecture parameter.