### PR TITLE
ci: add E2E API tests with OIDC Bedrock credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,87 @@ jobs:
             --parameter-overrides "Architecture=arm64" \
             -t template.yaml
 
+  e2e:
+    name: E2E API Tests
+    needs: [build]
+    # Skip scheduled runs and fork PRs (no OIDC access)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      API_KEY: test-ci-key
+      DEFAULT_MODEL: us.amazon.nova-lite-v1:0
+      ENABLE_CROSS_REGION_INFERENCE: 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Prepare source
+        run: ./prepare_source.sh
+
+      - name: Install dependencies
+        run: pip install -r layer/requirements.txt
+
+      - name: Start server
+        run: |
+          cd app && python3 api/app.py &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8000/api/v1/models -H "Authorization: Bearer $API_KEY" > /dev/null 2>&1; then
+              echo "Server ready"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Test - List models
+        run: |
+          RESP=$(curl -sf http://localhost:8000/api/v1/models -H "Authorization: Bearer $API_KEY")
+          echo "$RESP" | jq .
+          COUNT=$(echo "$RESP" | jq '.data | length')
+          [ "$COUNT" -gt 0 ] || (echo "FAIL: no models returned" && exit 1)
+
+      - name: Test - Chat completion
+        run: |
+          RESP=$(curl -sf http://localhost:8000/api/v1/chat/completions \
+            -H "Authorization: Bearer $API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{"model":"us.amazon.nova-lite-v1:0","messages":[{"role":"user","content":"Say hi in 3 words"}],"max_tokens":10}')
+          echo "$RESP" | jq .
+          echo "$RESP" | jq -e '.choices[0].message.content' || (echo "FAIL: no chat response" && exit 1)
+
+      - name: Test - Chat completion (streaming)
+        run: |
+          curl -sf http://localhost:8000/api/v1/chat/completions \
+            -H "Authorization: Bearer $API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{"model":"us.amazon.nova-lite-v1:0","messages":[{"role":"user","content":"Say hi"}],"max_tokens":10,"stream":true}' \
+            | grep -q 'data:' || (echo "FAIL: no streaming data" && exit 1)
+
+      - name: Test - Embeddings
+        run: |
+          RESP=$(curl -sf http://localhost:8000/api/v1/embeddings \
+            -H "Authorization: Bearer $API_KEY" \
+            -H "Content-Type: application/json" \
+            -d '{"model":"amazon.titan-embed-text-v2:0","input":"hello world"}')
+          echo "$RESP" | jq .
+          echo "$RESP" | jq -e '.data[0].embedding | length > 0' || (echo "FAIL: no embeddings" && exit 1)
+
+      - name: Test - Invalid auth rejected
+        run: |
+          HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/api/v1/models \
+            -H "Authorization: Bearer wrong-key")
+          [ "$HTTP_CODE" = "403" ] || [ "$HTTP_CODE" = "401" ] || (echo "FAIL: expected 401/403, got $HTTP_CODE" && exit 1)
+
   notify-upstream-drift:
     name: Check upstream drift
     if: github.event_name == 'schedule'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,14 +102,25 @@ jobs:
 
       - name: Start server
         run: |
-          cd app && python3 api/app.py &
+          cd app && PYTHONPATH=. python3 api/app.py > /tmp/server.log 2>&1 &
+          SERVER_PID=$!
           for i in $(seq 1 30); do
+            if ! kill -0 $SERVER_PID 2>/dev/null; then
+              echo "FAIL: server crashed on startup:"
+              cat /tmp/server.log
+              exit 1
+            fi
             if curl -sf http://localhost:8000/api/v1/models -H "Authorization: Bearer $API_KEY" > /dev/null 2>&1; then
               echo "Server ready"
               break
             fi
             sleep 1
           done
+          if ! curl -sf http://localhost:8000/api/v1/models -H "Authorization: Bearer $API_KEY" > /dev/null 2>&1; then
+            echo "FAIL: server not ready after 30s:"
+            cat /tmp/server.log
+            exit 1
+          fi
 
       - name: Test - List models
         run: |

--- a/e2e/oidc-role.yaml
+++ b/e2e/oidc-role.yaml
@@ -1,0 +1,75 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  GitHub Actions OIDC role for bedrock-access-gateway-function-url E2E tests.
+  Restricted to repo + actor:gabrielkoo only.
+
+Parameters:
+  GitHubOrg:
+    Type: String
+    Default: gabrielkoo
+  RepoName:
+    Type: String
+    Default: bedrock-access-gateway-function-url
+  OIDCProviderArn:
+    Type: String
+    Default: ''
+    Description: >
+      ARN of existing GitHub OIDC provider. Leave empty to create one.
+
+Conditions:
+  CreateOIDCProvider: !Equals [!Ref OIDCProviderArn, '']
+
+Resources:
+  GitHubOIDCProvider:
+    Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
+    Properties:
+      Url: https://token.actions.githubusercontent.com
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+        - 1c58a3a8518e8759bf075b76b750d4f2df264fcd
+
+  GitHubActionsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${RepoName}-e2e-ci'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !If
+                - CreateOIDCProvider
+                - !Ref GitHubOIDCProvider
+                - !Ref OIDCProviderArn
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+                token.actions.githubusercontent.com:sub: !Sub 'repo:${GitHubOrg}/${RepoName}:actor:${GitHubOrg}'
+      Policies:
+        - PolicyName: BedrockE2EAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: BedrockList
+                Effect: Allow
+                Action:
+                  - bedrock:ListFoundationModels
+                  - bedrock:ListInferenceProfiles
+                Resource: '*'
+              - Sid: BedrockInvoke
+                Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                  - bedrock:InvokeModelWithResponseStream
+                Resource:
+                  - arn:aws:bedrock:*::foundation-model/*
+                  - !Sub arn:aws:bedrock:*:${AWS::AccountId}:inference-profile/*
+
+Outputs:
+  RoleArn:
+    Value: !GetAtt GitHubActionsRole.Arn
+    Description: Use this as E2E_ROLE_ARN secret in GitHub Actions


### PR DESCRIPTION
## What

Add real E2E tests to CI that hit a locally-running FastAPI server against live Bedrock APIs.

## Tests
- **List models** — `GET /api/v1/models` returns non-empty list
- **Chat completion** — `POST /api/v1/chat/completions` with `nova-lite`
- **Streaming** — Same endpoint with `stream: true`, verify SSE data chunks
- **Embeddings** — `POST /api/v1/embeddings` with `titan-embed-text-v2`
- **Auth rejection** — Invalid API key returns 401/403

## Security
- Uses **GitHub Actions OIDC** to assume an IAM role (no long-lived secrets)
- OIDC subject claim customized to include `actor` — only workflows triggered by `gabrielkoo` can assume the role
- IAM role has minimal Bedrock permissions only (`InvokeModel`, `ListFoundationModels`, `ListInferenceProfiles`)
- CloudFormation template included at `e2e/oidc-role.yaml` for reproducibility

## Cost
- Uses cheapest models: `us.amazon.nova-lite-v1:0` (chat) + `amazon.titan-embed-text-v2:0` (embeddings)
- `max_tokens: 10` on all chat requests
- Estimated cost per run: < $0.001